### PR TITLE
Add content-type and standardize nested elements

### DIFF
--- a/spec/v1-alpha/schema.json
+++ b/spec/v1-alpha/schema.json
@@ -6,6 +6,7 @@
             "value": "Atomicfile",
             "description": "application manifest",
             "elementType": "file",
+            "contentType": "application/json",
             "contents": {
                 "name": "String",
                 "description": "String",
@@ -21,6 +22,7 @@
             "value": "README.md",
             "description": "information for deploying this application targetted towards deployment ops sysadmin",
             "elementType": "file",
+            "contentType": "text/plain",
             "contents": null
         },
         {
@@ -28,6 +30,7 @@
             "value": "Dockerfile",
             "description": "standard packaging for this application metadata",
             "elementType": "file",
+            "contentType": "text/plain",
             "contents": "FROM scratch\n\nADD / /application-entity"
         },
         {
@@ -35,6 +38,7 @@
             "value": "params.conf",
             "description": "runtime parameters for application",
             "elementType": "file",
+            "contentType": "text/plain",
             "contents": "[general]\n\n"
         },
         {
@@ -71,6 +75,7 @@
                             "value": "params.conf",
                             "description": "runtime parameters for application",
                             "elementType": "file",
+                            "contentType": "text/plain",
                             "contents": "[general]\n\n"
                         }
                     ]

--- a/spec/v1-alpha/schema.json
+++ b/spec/v1-alpha/schema.json
@@ -9,6 +9,7 @@
             "contentType": "application/json",
             "contents": {
                 "name": "String",
+                "id": "String",
                 "description": "String",
                 "appversion": "String",
                 "graph": [
@@ -43,6 +44,7 @@
         },
         {
             "name": "graph",
+            "value": "graph",
             "description": "directories of applications referenced in Atomicfile separated by provisioning provider",
             "elementType": "directory",
             "contents": [
@@ -54,16 +56,13 @@
                     "contents": [
                         {
                             "name": "provider",
-                            "value": [
-                                "kubernetes",
-                                "docker",
-                                "systemd",
-                                "heat"
-                            ],
-                            "description": "a directory whose name matches a list of container or orchestration technologies",
+                            "value": "provider",
+                            "description": "a directory whose name matches a list of container or orchestration technologies available in selected implementation",
+                            "elementType": "directory",
                             "contents": [
                                 {
                                     "name": "provider files",
+                                    "value": null,
                                     "description": "provider-specific files necessary for deploying to provider, e.g. kubernetes pod and service files",
                                     "elementType": "file",
                                     "contents": null


### PR DESCRIPTION
This PR contains 2 commits:
1. For every file provide content type
- might be useful for validation although it's mostly text/plain anyway (only Atomicfile is different)
1. Standardize nested elements
2. some elements missed value which is bad for tools
3. I removed list of providers as this is implementation specific
