### PR TITLE
Add support for multiple providers, add artifacts list

### DIFF
--- a/spec/v1-alpha/examples/ruby/template.yaml
+++ b/spec/v1-alpha/examples/ruby/template.yaml
@@ -38,43 +38,64 @@ parameters:
 
 items:
   rubyserver:
-    type: kubernetes::openshift
-    deploy:
-      - get_file: k8s/frontend_service.json
-      - template: {get_file: k8s/frontend_rc.json}
+    - provider0:
+      type: kubernetes::openshift
+      deploy:
+        artifacts: 
+          - k8s/frontend_service.json
+          - k8s/frontend_rc.json
         params:
           $ADMIN_USERNAME: {get_param: admin_username}
           $ADMIN_PASSWORD: {get_param: admin_password}
           $MYSQL_USER: {get_param: database_username}
           $MYSQL_PASSWORD: {get_param: database_password}
           $MYSQL_DATABASE: {get_param: database_name}
-    triggers:
-      imageChangeParams:
-        automatic: true,
-        containerNames:
-          - ruby-helloworld
-        from:
-          name: origin-ruby-sample
-        tag: latest
-      type: ImageChange
+      triggers:
+        imageChangeParams:
+          automatic: true,
+          containerNames:
+            - ruby-helloworld
+          from:
+            name: origin-ruby-sample
+          tag: latest
+        type: ImageChange
+    - provider1:
+        type: docker::label
+        deploy:
+          params:
+            $ADMIN_USERNAME: {get_param: admin_username}
+            $ADMIN_PASSWORD: {get_param: admin_password}
+            $MYSQL_USER: {get_param: database_username}
+            $MYSQL_PASSWORD: {get_param: database_password}
+            $MYSQL_DATABASE: {get_param: database_name}
 
   mysql:
-    type: kubernetes::openshift
-    deploy:
-      - get_file: k8s/database_service.json
-      - template: {get_file: k8s/database_rc.json}
+    - provider0:
+      type: kubernetes::openshift
+      deploy:
+        artifacts:
+          - k8s/database_service.json
+          - k8s/database_rc.json
         params:
           $MYSQL_USER: {get_param: database_username}
           $MYSQL_PASSWORD: {get_param: database_password}
           $MYSQL_DATABASE: {get_param: database_name}
-    triggers:
-      type: ConfigChange
-    strategy:
-      type: Recreate
+      triggers:
+        type: ConfigChange
+      strategy:
+        type: Recreate
+    - provider1:
+      type: docker::label
+      deploy:
+        params:
+          $MYSQL_USER: {get_param: database_username}
+          $MYSQL_PASSWORD: {get_param: database_password}
+          $MYSQL_DATABASE: {get_param: database_name}
 
   route:
     type: openshift
     deploy:
-      - template: {get_file: openshift/route.json}
-        params:
-          $HOSTNAME: {get_param: hostname}
+      artifacts:
+        - penshift/route.json
+      params:
+        $HOSTNAME: {get_param: hostname}


### PR DESCRIPTION
I still miss the support for more providers, but I like the approach of specifying type of provide in template.yaml. I added draft for docker provider based on image metadata labels (i.e. type: docker::label).

I am not sure if we need to specify params for every provider - it might be worth considering if it would be enough to have a global params for all providers in each item (Can params differ based on used provider?)

Also I don't understand the need for explicitly saying {get_file: ...} thus I added part artefacts. Listing files specific for an item is good as it unbinds us from having explicit naming policy for directory structure, but I think simple list of artefacts.
