### PR TITLE
Artifacts sliped out of component object by my previous commit

### DIFF
--- a/spec/0.0.1-alpha/schema.json
+++ b/spec/0.0.1-alpha/schema.json
@@ -128,28 +128,28 @@
                                             }
                                         }
                                     }
-                                }
-                            }
-                        },
-                        "artifacts": {
-                            "required": false,
-                            "description": "A list of ArtifactsObject that contain provider specific information. If artifacts is present, source field SHALL be ignored.",
-                            "type": "object",
-                            "value": {
-                                "provider": {
-                                    "required": true,
-                                    "description": "Name of the provider",
-                                    "name": [
-                                        "kubernetes",
-                                        "openshift"
-                                    ],
-                                    "type": "list",
+                                },
+                                "artifacts": {
+                                    "required": false,
+                                    "description": "A list of ArtifactsObject that contain provider specific information. If artifacts is present, source field SHALL be ignored.",
+                                    "type": "object",
                                     "value": {
-                                        "artifact": {
+                                        "provider": {
                                             "required": true,
-                                            "description": "Path to the artifact",
-                                            "type": "string",
-                                            "value": null
+                                            "description": "Name of the provider",
+                                            "name": [
+                                                "kubernetes",
+                                                "openshift"
+                                            ],
+                                            "type": "list",
+                                            "value": {
+                                                "artifact": {
+                                                    "required": true,
+                                                    "description": "Path to the artifact",
+                                                    "type": "string",
+                                                    "value": null
+                                                }
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
I broke it - `artifacts` got to highest level of Atomicfile instead of being under `component`
