### PR TITLE
Split schema into files matching the object definition in spec

### DIFF
--- a/spec/0.0.1-alpha/compose/README.md
+++ b/spec/0.0.1-alpha/compose/README.md
@@ -1,0 +1,33 @@
+# Schema Composer
+Nulecule spec provides schema in json format which servers as a machine readable alternative to textual specification. To make the schema more consumable we've split it to multiple file representing objects in specification (`GraphObject`, `MetadataObject`, etc.). The purpose of this tool is to compose these separate objects into one giant json file representing whole schema. 
+
+Objects are referenced by option with key `ref`. The value of `ref` can be relative path or URL.
+
+## How to Use
+```
+usage: compose.py [-h] [--output OUTPUT] [-v] SCHEMA
+
+This tool lets you compose schema containing references into a single file
+
+positional arguments:
+  SCHEMA           Path/URL to the main schema file
+
+optional arguments:
+  -h, --help       show this help message and exit
+  --output OUTPUT  Path to a file which will containt composed schema file if
+                   the composition succeedes
+  -v, --verbose    Make the output more verbose
+```
+
+### Example
+
+Schema can be specified by URL which means for all references which paths are specified as relative will be prefixed with the url to the main schema file.
+```
+compose.py https://raw.githubusercontent.com/vpavlin/nulecule/master/spec/0.0.1-alpha/schema.json --output composed_schema.json -v
+```
+
+You can run the tool also on local files. Similarly to the example above - all relative paths in references will be prefixed with absolute path to the directory schema.json lives in
+```
+compose.py schema.json --output composed_schema.json -v
+```
+

--- a/spec/0.0.1-alpha/compose/compose.py
+++ b/spec/0.0.1-alpha/compose/compose.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+
+import logging
+import os
+import json
+import urllib2
+import tempfile
+from argparse import ArgumentParser
+from argparse import RawDescriptionHelpFormatter
+
+
+logging.basicConfig()
+logger = logging.getLogger("compose")
+logger.setLevel(logging.INFO)
+
+MAIN_FILE = "Atomicfile"
+
+class Compose(object):
+    schema_url = None
+    __schema_path = None
+    __schema_dir = None
+    __schema = None
+    __tmpdir = None
+
+    @property
+    def tmpdir(self):
+        if not self.__tmpdir:
+            self.__tmpdir = tempfile.mkdtemp(prefix="nulecule-spec-") 
+            logger.info("Using temporary directory %s" % self.__tmpdir)
+
+        return self.__tmpdir
+
+    @property
+    def schema_dir(self):
+        if not self.__schema_dir:
+            if self.schema_url:
+                self.__schema_dir = os.path.dirname(self.schema_path)
+            else:
+                self.__schema_dir = os.path.abspath(os.path.dirname(self.schema_path))
+            logger.debug("Setting 'schema_dir' to %s" % self.__schema_dir)
+        return self.__schema_dir
+
+    @property
+    def schema_path(self):
+        if not self.__schema_path:
+            self.__schema_path, _ = self.download(self.schema_url)
+            logger.debug("Setting 'schema_path to %s" % self.__schema_path)
+        return self.__schema_path
+
+    @schema_path.setter
+    def schema_path(self, path):
+        self.__schema_path = path
+        logger.debug("Schema path is %s" % os.path.dirname(path))
+
+    @property
+    def schema(self):
+        if not self.__schema:
+            self.__schema = self.loadSchema(self.schema_path)
+        return self.__schema
+
+    def __init__(self, schema):
+        if os.path.isfile(schema):
+            self.schema_path = schema
+        else:
+            logger.debug("Given schema is not stored locally")
+            self.schema_url = schema
+        
+    def loadSchema(self, schema_path):
+        if not os.path.isfile(schema_path):
+            raise Exception("Path to schema %s does not exist" % schema_path)
+
+        content = None
+        with open(schema_path, "r") as fp:
+            content = json.load(fp)
+
+        if not content:
+            raise Exception("Couldn't load content of %s" % schema_path)
+
+        return content
+
+    def download(self, url):
+        data = self.getData(url)
+        output_name = os.path.basename(url)
+        path = os.path.join(self.tmpdir, output_name)
+        with open(path, "w") as fp:
+            fp.write(data)
+
+        return path, data
+
+    def getUrl(self, ref):
+        path = None
+        if self.schema_url:
+            path = os.path.join(os.path.dirname(self.schema_url), ref)
+        else:
+            path = "file://%s" % os.path.join(self.schema_dir, ref)
+
+        return path
+
+    def getData(self, ref):
+        logger.debug("Loading data for %s" % ref)
+        try:
+            ref_data = urllib2.urlopen(ref)
+        except ValueError:
+            ref = self.getUrl(ref)
+            logger.debug("Real path to load from is %s" % ref)
+            ref_data = urllib2.urlopen(ref)
+
+        return ref_data.read()
+
+    def getRefObject(self, ref_data):
+        return json.loads(ref_data)
+
+    def composeSchema(self, data):
+        for name, contents in data.iteritems():
+            if "ref" in contents:
+                logger.info("Pulling content for %s from %s" % (name, contents["ref"]))
+                _, ref_data = self.download(contents["ref"])
+                contents.update(self.getRefObject(ref_data))
+                del contents["ref"]
+            if "value" in contents and contents["value"]:
+                if type(contents["value"]) == dict:
+                    self.composeSchema(contents["value"])
+                elif type(contents["value"]) == list:
+                    for item in contents["value"]:
+                        if type(item) == dict:
+                            self.composeSchema(item)
+
+    def writeSchema(self, output_file):
+        with open(output_file, "w") as fp:
+            fp.write(self.serializeSchema())
+
+    def serializeSchema(self):
+        return json.dumps(self.schema,sort_keys=True, indent=4, separators=(',', ': '))
+
+    def run(self, output_file=None):
+        main_schema = None
+
+        for element in self.schema["elements"]:
+            if type(element["contents"]) is dict:
+                main_schema = element["contents"]
+                self.composeSchema(main_schema)
+
+        if output_file:
+            self.writeSchema(output_file)
+        else:
+            print(self.serializeSchema())
+
+        
+
+def main():
+    parser = ArgumentParser(description='This tool lets you compose schema containing references into a single file', formatter_class=RawDescriptionHelpFormatter)
+    parser.add_argument("SCHEMA", help="Path/URL to the main schema file")
+    parser.add_argument("--output", dest="output", help="Path to a file which will containt composed schema file if the composition succeedes")
+    parser.add_argument("-v", "--verbose", default=False, action="store_true", dest="verbose", help="Make the output more verbose")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
+    comp = Compose(args.SCHEMA)
+    comp.run(args.output)
+
+if __name__ == '__main__':
+    main()

--- a/spec/0.0.1-alpha/constraint.json
+++ b/spec/0.0.1-alpha/constraint.json
@@ -1,0 +1,19 @@
+{
+    "description": "Constraint to the parameter.",
+    "name": "constraint%d",
+    "type": "object",
+    "value": {
+        "allowed_pattern": {
+            "multiplicity": "1",
+            "description": "A regular expression pattern.",
+            "type": "string",
+            "value": null
+        },
+        "description": {
+            "multiplicity": "1",
+            "description": "A human readable description of the constraint.",
+            "type": "string",
+            "value": null
+        }
+    }
+}

--- a/spec/0.0.1-alpha/graph.json
+++ b/spec/0.0.1-alpha/graph.json
@@ -1,0 +1,43 @@
+{
+    "description": "A list of depending containerapps. Strings may either match a local sub directory or another containerapp-spec compliant containerapp image that can be pulled via a provider.",
+    "name": "graph",
+    "type": "collection",
+    "value": {
+        "component": {
+            "multiplicity": "1..n",
+            "name": null,
+            "description": "Id of a component",
+            "type": "object",
+            "value": {
+                "source": {
+                    "multiplicity": "0..1",
+                    "description": "Source location of the Container Application, the source MUST be specified by a valid URL. If source is present, all other fields SHALL be ignored.",
+                    "type": "url",
+                    "value": null
+                },
+                "params": {
+                    "multiplicity": "0..1",
+                    "description": "A list of ParamsObject that contain provider specific information. If params is present, source field SHALL be ignored.",
+                    "type": "collection",
+                    "value": {
+                        "param": {
+                            "ref": "param.json",
+                            "multiplicity": "1..n"
+                        }
+                    }
+                },
+                "artifacts": {
+                    "multiplicity": "0..1",
+                    "description": "A list of ArtifactsObject that contain provider specific information. If artifacts is present, source field SHALL be ignored.",
+                    "type": "collection",
+                    "value": {
+                        "provider": {
+                            "ref": "provider.json",
+                            "multiplicity": "1..n"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/spec/0.0.1-alpha/license.json
+++ b/spec/0.0.1-alpha/license.json
@@ -1,0 +1,19 @@
+{
+    "description": "License information for the Container Application.",
+    "name": "license",
+    "type": "object",
+    "value": {
+        "name": {
+            "multiplicity": "1",
+            "description": "The human readable license name used for the Container Application, no format imposed.",
+            "type": "string",
+            "value": null
+        },
+        "url": {
+            "multiplicity": "0..1",
+            "description": "A URL to the license used for the API. MUST be in the format of a URL.",
+            "type": "url",
+            "value": null
+        }
+    }
+}

--- a/spec/0.0.1-alpha/metadata.json
+++ b/spec/0.0.1-alpha/metadata.json
@@ -1,0 +1,29 @@
+{
+    "name": "metadata",
+    "description": "An object holding optional metadata related to the Container Application, this may include license information or human readable information.",
+    "type": "object",
+    "value": {
+        "name": {
+            "multiplicity": "0..1",
+            "description": "A human readable name of the containerapp.",
+            "type": "string",
+            "value": null
+        },
+        "appversion": {
+            "multiplicity": "0..1",
+            "description": "The semantic version string of the Container Application.",
+            "type": "string",
+            "value": null
+        },
+        "description": {
+            "multiplicity": "0..1",
+            "description": "A human readable description of the Container Application. This may contain information for the deployer of the containerapp.",
+            "type": "string",
+            "value": null
+        },
+        "license": {
+            "ref": "license.json",
+            "multiplicity": "0..1"
+        }
+    }
+}

--- a/spec/0.0.1-alpha/param.json
+++ b/spec/0.0.1-alpha/param.json
@@ -1,0 +1,30 @@
+{
+    "name": null,
+    "description": "Name of the parameter as used in artifacts",
+    "type": "object",
+    "value": {
+        "description": {
+            "multiplicity": "1",
+            "description": "A human readable description of the parameter.",
+            "type": "string",
+            "value": null
+        },
+        "constraints": {
+            "multiplicity": "0..1",
+            "description": "An optional definition of constraints to the parameter.",
+            "type": "list",
+            "value": {
+                "constraint": {
+                    "ref": "constraint.json",
+                    "multiplicity": "1..n"
+                }
+            }
+        },
+        "default": {
+            "multiplicity": "0..1",
+            "description": "An optional default value for the parameter.",
+            "type": "string",
+            "value": null
+        }
+    }
+}

--- a/spec/0.0.1-alpha/provider.json
+++ b/spec/0.0.1-alpha/provider.json
@@ -1,0 +1,24 @@
+{
+    "description": "Name of the provider",
+    "name": [
+        "kubernetes",
+        "openshift"
+    ],
+    "type": "list",
+    "value": {
+        "artifact": {
+            "multiplicity": "1..n",
+            "name": null,
+            "description": "Path to the artifact",
+            "type": "string",
+            "value": null
+        },
+        "inherit": {
+            "multiplicity": "0..1",
+            "name": "inherit",
+            "description": "List of components whose artifacts will be added to the list of artifacts for the provider.",
+            "type": "list",
+            "value": null
+        }
+    }
+}

--- a/spec/0.0.1-alpha/requirement.json
+++ b/spec/0.0.1-alpha/requirement.json
@@ -4,7 +4,9 @@
     "type": "list",
     "value": [
         {
-            "ref": "requirements/persistentvolume.json"
+            "persistentVolume": {
+                "ref": "requirements/persistentvolume.json"
+            }
         }
     ]
 }

--- a/spec/0.0.1-alpha/requirement.json
+++ b/spec/0.0.1-alpha/requirement.json
@@ -1,0 +1,10 @@
+{
+    "description": "Requirement object",
+    "name": null,
+    "type": "list",
+    "value": [
+        {
+            "ref": "requirements/persistentvolume.json"
+        }
+    ]
+}

--- a/spec/0.0.1-alpha/requirements/persistentvolume.json
+++ b/spec/0.0.1-alpha/requirements/persistentvolume.json
@@ -1,0 +1,28 @@
+{
+    "description": "This describes a requirement for persistent, read-only or read-write storage that should be available to the containerapp on runtime. The name of this object MUST be 'persistentVolume'",
+    "type": "object",
+    "name": "persistentVolume",
+    "value": {
+        "name": {
+            "multiplicity": "1",
+            "description": "A name associated with the storage requirement.",
+            "type": "string",
+            "value": null
+        },
+        "accessMode": {
+            "description": "Access mode in which the persitent volume will be available",
+            "multiplicity": "1",
+            "type": "string",
+            "value": [
+                "ReadWrite",
+                "ReadOnly"
+            ]
+        },
+        "size": {
+            "description": "Size of required the storage.",
+            "multiplicity": "1",
+            "type": "integer",
+            "value": null
+        }
+    }
+}

--- a/spec/0.0.1-alpha/schema.json
+++ b/spec/0.0.1-alpha/schema.json
@@ -2,6 +2,7 @@
     "version": "0.0.1-alpha",
     "description": "The Container Application specification is a project to describe 'an Application' that is composed of a set of dependent Container Applications (containerapp). The Container Application specification defines a set of files required to describe such a containerapp. These files can then be used by other tools to deploy a containerapp. Developers may use other tools to generate most of the required containerapp files. Additional utilities can also take advantage of the resulting files, such as testing tools.",
     "format": "The files describing a containerapp in accordance with the Container Application Specification are represented using YAML 1.2 or JSON.",
+    "source": "https://raw.githubusercontent.com/projectatomic/nulecule/master/spec/0.0.1-alpha/schema.json",
     "elements": [
         {
             "name": "Atomicfile",
@@ -11,165 +12,33 @@
             "required": true,
             "contents": {
                 "id": {
-                    "required": true,
+                    "multiplicity": "1",
                     "description": "The machine readable id of the Container Application.",
                     "type": "string",
                     "value": null
                 },
                 "specversion": {
-                    "required": true,
+                    "multiplicity": "1",
                     "description": "The semantic version string of the Container Application Specification used to describe the app. The value MUST be '0.0.1-alpha'.",
                     "type": "string",
                     "value": "0.0.1-alpha"
                 },
                 "metadata": {
-                    "required": false,
-                    "description": "An object holding optional metadata related to the Container Application, this may include license information or human readable information.",
-                    "type": "object",
-                    "value": {
-                        "name": {
-                            "required": false,
-                            "description": "A human readable name of the containerapp.",
-                            "type": "string",
-                            "value": null
-                        },
-                        "appversion": {
-                            "required": false,
-                            "description": "The semantic version string of the Container Application.",
-                            "type": "string",
-                            "value": null
-                        },
-                        "description": {
-                            "required": false,
-                            "description": "A human readable description of the Container Application. This may contain information for the deployer of the containerapp.",
-                            "type": "string",
-                            "value": null
-                        },
-                        "license": {
-                            "required": false,
-                            "description": "",
-                            "type": "object",
-                            "value": {
-                                "name": {
-                                    "required": true,
-                                    "description": "The human readable license name used for the Container Application, no format imposed.",
-                                    "type": "string",
-                                    "value": null
-                                },
-                                "url": {
-                                    "required": false,
-                                    "description": "A URL to the license used for the API. MUST be in the format of a URL.",
-                                    "type": "string",
-                                    "value": null
-                                }
-                            }
-                        }
-                    }
+                    "ref": "metadata.json",
+                    "multiplicity": "0..1"
                 },
                 "graph": {
-                    "required": true,
-                    "description": "A list of depending containerapps. Strings may either match a local sub directory or another containerapp-spec compliant containerapp image that can be pulled via a provider.",
-                    "type": "object",
-                    "value": {
-                        "component": {
-                            "required": true,
-                            "name": null,
-                            "description": "Id of a component",
-                            "type": "object",
-                            "value": {
-                                "source": {
-                                    "required": false,
-                                    "description": "Source location of the Container Application, the source MUST be specified by a valid URL. If source is present, all other fields SHALL be ignored.",
-                                    "type": "url",
-                                    "value": null
-                                },
-                                "params": {
-                                    "required": false,
-                                    "description": "A list of ParamsObject that contain provider specific information. If params is present, source field SHALL be ignored.",
-                                    "type": "object",
-                                    "value": {
-                                        "param": {
-                                            "required": true,
-                                            "name": null,
-                                            "description": "Name of the parameter as used in artifacts",
-                                            "type": "object",
-                                            "value": {
-                                                "description": {
-                                                    "required": true,
-                                                    "description": "A human readable description of the parameter.",
-                                                    "type": "string",
-                                                    "value": null
-                                                },
-                                                "constraints": {
-                                                    "required": false,
-                                                    "description": "An optional definition of constraints to the parameter.",
-                                                    "type": "object",
-                                                    "value": {
-                                                        "allowed_pattern": {
-                                                            "required": true,
-                                                            "description": "A regular expression pattern.",
-                                                            "type": "string",
-                                                            "value": null
-                                                        },
-                                                        "description": {
-                                                            "required": true,
-                                                            "description": "A human readable description of the constraint.",
-                                                            "type": "string",
-                                                            "value": null
-                                                        }
-                                                    }
-                                                },
-                                                "default": {
-                                                    "required": false,
-                                                    "description": "An optional default value for the parameter.",
-                                                    "type": "string",
-                                                    "value": null
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "artifacts": {
-                                    "required": false,
-                                    "description": "A list of ArtifactsObject that contain provider specific information. If artifacts is present, source field SHALL be ignored.",
-                                    "type": "object",
-                                    "value": {
-                                        "provider": {
-                                            "required": true,
-                                            "description": "Name of the provider",
-                                            "name": [
-                                                "kubernetes",
-                                                "openshift"
-                                            ],
-                                            "type": "list",
-                                            "value": {
-                                                "artifact": {
-                                                    "required": true,
-                                                    "description": "Path to the artifact",
-                                                    "type": "string",
-                                                    "value": null
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    "ref": "graph.json",
+                    "multiplicity": "1"
                 },
                 "requirements": {
-                    "required": false,
+                    "multiplicity": "0..1",
                     "description": "A list of requirements of this containerapp.",
                     "type": "object",
                     "value": {
                         "requirement": {
-                            "required": true,
-                            "description": "Requirement object ",
-                            "name": [
-                                "persistentVolume"
-                            ],
-                            "type": "list",
-                            "value": null
+                            "ref": "requirement.json",
+                            "multiplicity": "1..n"
                         }
                     }
                 }


### PR DESCRIPTION
I find the single spec file hard to digest, thus I tried and split it
into multiple files. These should match objects in spec. Use case for
this, apart from readability, is that I'd probably like to generate
python classes for every object so that it's easier to work with them,
validate them and compose nulecule app from them. (It's still only a blurry idea)

Also I replaced `required` option with `multiplicity` which will help
during implementation with discovering which objects are repeatable and
which should be defined only once, at least once etc.

TODO:
- Implement a simple script to compose spec into single file
- Think about adding an unique `id` key to every item which would let us easily search in the schema similarly to how xpath works.
