### PR TITLE
Added a list of required files (fixes #45)

### DIFF
--- a/spec/0.0.2/README.md
+++ b/spec/0.0.2/README.md
@@ -299,8 +299,12 @@ artifacts: # list of files to be processed by the provider selected at install-t
 
 ## Directory Layout
 
+Names of files that must be present are contained in the file `files` in
+the root directory of the specification. These filenames support globbing.
+
+A filesystem layout of a typical app is this:
 ```
-├── Nulecule 
+├── Nulecule
 ├── Dockerfile
 ├── <provider_files_dir>
 │   ├── ...

--- a/spec/0.0.2/files
+++ b/spec/0.0.2/files
@@ -1,0 +1,2 @@
+Dockerfile
+Nulecule


### PR DESCRIPTION
This commit introduces a file named `files` in the spec's root directory, which contains a list of filenames that _must_ be present in an app's directory. `README.md` is also changed appropriately.

This PR is the solution to issue #45.
