### PR TITLE
Changed "value" occurrences to "default" (fixes #75)

### DIFF
--- a/spec/0.0.2/license.json
+++ b/spec/0.0.2/license.json
@@ -9,12 +9,12 @@
         "name": {
             "description": "The human readable license name used for the Container Application, no format imposed.",
             "type": "string",
-            "value": "null"
+            "default": "null"
         },
         "url": {
             "description": "A URL to the license used for the API. MUST be in the format of a URL.",
             "type": "string",
-            "value": "null"
+            "default": "null"
         }
     }
 }

--- a/spec/0.0.2/provider.json
+++ b/spec/0.0.2/provider.json
@@ -12,7 +12,7 @@
         "path": {
             "description": "Path to the artifact",
             "type": "string",
-            "value": "null"
+            "default": "null"
         },
         "inheritance": {
             "type": "object",

--- a/spec/0.0.2/requirements/persistentvolume.json
+++ b/spec/0.0.2/requirements/persistentvolume.json
@@ -12,7 +12,7 @@
                 "name": {
                     "description": "A name associated with the storage requirement.",
                     "type": "string",
-                    "value": "null"
+                    "default": "null"
                 },
                 "accessMode": {
                     "description": "Access mode in which the persitent volume will be available",


### PR DESCRIPTION
As per the JSON Schema specification, default values are to be defined with
the keyword "default", as opposed to "value".

http://json-schema.org/latest/json-schema-validation.html#anchor101
