### PR TITLE
Modify README.md regarding default values and providers

### DIFF
--- a/examples/helloapache/README.md
+++ b/examples/helloapache/README.md
@@ -1,13 +1,15 @@
-This is an atomic application based on the nulecule specification. Kubernetes is currently the only supported provider. You'll need to run this from a workstation that has the atomic CLI and kubectl client that can connect to a kubernetes master.
+This is an atomic application based on the nulecule specification. Kubernetes and native docker are currently the only supported providers. You'll need to run this from a workstation that has the atomic command.  If you wish to use the kubernetes provider, you will also need a kubectl client that can connect to a kubernetes master.
 
 It's a single pod based on the centos/httpd image, but you can use your own.
 
-### Option 1: Non-interactive defaults
+### Option 1: Non-interactive using defaults
 
 Run the image. It will automatically use kubernetes as the orchestration provider.
 ```
 [sudo] atomic run projectatomic/helloapache
 ```
+
+Note: This option is not interactive because all params in the Nulecule file have default values.
 
 ## Option 2: Unattended
 


### PR DESCRIPTION
Note that it is the default values in the Nulecule file that
make Option #1 non-interactive

Add a reference to the docker provider in the opening paragraph
