### PR TITLE
Change name for httpd container in docker provider

### DIFF
--- a/examples/helloapache/artifacts/docker/hello-apache-pod_run
+++ b/examples/helloapache/artifacts/docker/hello-apache-pod_run
@@ -1,1 +1,1 @@
-docker run -d --name helloapache -p $hostport:80 $image
+docker run -d --name helloapache-httpd -p $hostport:80 $image


### PR DESCRIPTION
helloapache isn't acceptable as it duplicates the name of the
running atomicapp
