### PR TITLE
Updated redis-centos7-atomic app example

### DIFF
--- a/examples/redis-centos7-atomicapp/Nulecule
+++ b/examples/redis-centos7-atomicapp/Nulecule
@@ -5,7 +5,7 @@ id: redis-atomicapp
 metadata:
   name: Redis App
   appversion: 0.0.1
-  description: Redis atomic app
+  description: Redis Atomic App
 graph:
   - name: redismaster-app
     params:
@@ -24,6 +24,9 @@ graph:
       - name: image
         description: The redis slave part
         default: jasonbrooks/redis
+      - name: master_hostport
+        description: The host TCP port of the redis master
+        default: 6379
       - name: hostport
         description: The host TCP port as the external endpoint
         default: 6379
@@ -31,4 +34,3 @@ graph:
       kubernetes:
         - file://artifacts/k8s/redis-slave-controller.json
         - file://artifacts/k8s/redis-slave-service.json
-

--- a/examples/redis-centos7-atomicapp/README.md
+++ b/examples/redis-centos7-atomicapp/README.md
@@ -1,21 +1,76 @@
+# redis-centos7-atomicapp
+
 This is a redis sample application, in which redis master and slave components are packaged as an atomic application based on the nulecule specification. 
 
-Kubernetes is currently the only supported provider. You'll need to run this from a workstation that has the atomic CLI and kubectl client that can connect to a kubernetes master. This example depends on kube-dns being configured on your kubernetes cluster.
+Kubernetes and native docker are currently the only supported providers. You'll need to run this from a workstation that has the atomic command.  If you wish to use the kubernetes provider, you will also need a kubectl client that can connect to a kubernetes master.
 
-### Step 1
+## Option 1: Non-interactive defaults
 
-Build this app:
+Run the image. It will automatically use kubernetes as the orchestration provider.
+
+    $ [sudo] atomic run projectatomic/redis-centos7-atomicapp
+
+Note: This option is not interactive because all params in the Nulecule file have default values.
+
+## Option 2: Unattended
+
+1. Create the file `answers.conf` with these contents:
+
+    This changes the port for the master from the default of 6379 to 16379. and indicates that kubernetes should be the orchestration provider.
+
+    [general]
+    namespace = default
+    provider = kubernetes
+    [redismaster-app]
+    hostport = 16379
+    [redisslave-app]
+    master_hostport = 16379
+
+1. Run the application from the current working directory
+
+        $ [sudo] atomic run projectatomic/redis-centos7-atomicapp
+
+1. As an additional experiment, remove the kubernetes pod and change the provider to 'docker' and re-run the application to see it get deployed on base docker.
+
+## Option 3: Install and Run
+
+You may want to download the application, review the configuraton and parameters as specified in the Nulecule file, and edit the answerfile before running the application.
+
+1. Download the application files using `atomic install`
+
+        $ [sudo] atomic install projectatomic/redis-centos7-atomicapp
+
+1. Rename `answers.conf.sample`
+
+        mv answers.conf.sample answers.conf
+
+1. Edit `answers.conf`, review files if desired and then run
+
+        $ [sudo] atomic run projectatomic/redis-centos7-atomicapp
+
+## Test
+Any of these approaches should create a kubernetes service or a pair of running docker containers. 
+
+With a kubernetes service, once its pods are in the "Running" state, you can use the redis-cli to access the server.  The example below uses the `redis-cli` in the redis container.
 
 ```
-atomicapp build $USER/redis-centos7-atomicapp
+$ kubectl get service redis-master
+NAME           LABELS                   SELECTOR                 IP              PORT(S)
+redis-master   name=redis,role=master   name=redis,role=master   <IP Address>    <port>/TCP
+$ docker run --rm -it jasonbrooks/redis redis-cli -h <IP Address> -p <port>
+<IP Address>:<port>> get key
+(nil)
+<IP Address>:<port>> set key value
+OK
+<IP Address>:<port>> get key
+"value"
+<IP Address>:<port>> del key
+(integer) 1
+<IP Address>:<port>> get key
+(nil)
+<IP Address>:<port>> exit
 ```
 
-### Step 2 
+Clean up can be accomplished by deleting the pods, service, and replication controllers as follows:
 
-Run this app:
-
-```
-atomic run $USER/redis-centos7-atomicapp
-```
-
-
+    $ kubectl delete pod,rc,svc -l name=redis

--- a/examples/redis-centos7-atomicapp/answers.conf
+++ b/examples/redis-centos7-atomicapp/answers.conf
@@ -1,2 +1,0 @@
-[general]
-provider = kubernetes

--- a/examples/redis-centos7-atomicapp/artifacts/k8s/redis-master-controller.json
+++ b/examples/redis-centos7-atomicapp/artifacts/k8s/redis-master-controller.json
@@ -30,7 +30,7 @@
                   "ports":[
                      {
                         "name":"redis-server",
-                        "containerPort":6379,
+                        "containerPort":$hostport,
                         "protocol":"TCP"
                      }
                   ]

--- a/examples/redis-centos7-atomicapp/artifacts/k8s/redis-master-service.json
+++ b/examples/redis-centos7-atomicapp/artifacts/k8s/redis-master-service.json
@@ -11,7 +11,7 @@
    "spec":{
       "ports": [
         {
-          "port":6379,
+          "port":$hostport,
           "targetPort":"redis-server",
           "protocol":"TCP"
         }

--- a/examples/redis-centos7-atomicapp/artifacts/k8s/redis-slave-controller.json
+++ b/examples/redis-centos7-atomicapp/artifacts/k8s/redis-slave-controller.json
@@ -30,12 +30,12 @@
                   "command":[
                      "sh",
                      "-c",
-                     "redis-server /etc/redis.conf --slaveof redis-master 6379"
+                     "redis-server /etc/redis.conf --slaveof redis-master $master_hostport"
                   ],
                   "ports":[
                      {
                         "name":"redis-server",
-                        "containerPort":6379,
+                        "containerPort":$hostport,
                         "protocol":"TCP"
                      }
                   ]

--- a/examples/redis-centos7-atomicapp/artifacts/k8s/redis-slave-service.json
+++ b/examples/redis-centos7-atomicapp/artifacts/k8s/redis-slave-service.json
@@ -11,7 +11,7 @@
    "spec":{
       "ports": [
         {
-          "port":6379,
+          "port":$hostport,
           "targetPort":"redis-server",
           "protocol":"TCP"
         }


### PR DESCRIPTION
1. This moves to fixing issue #123 by removing references to atomicapp
   build
2. Removed answers.conf as it is not needed in the repo
3. Updated Readme.md to walk through examples and show testing
4. Updated K8s artifacts to actually use the hostport params
5. Added a master_host parm for the slave so it can find the master
   Ideally we should address with some global variables see issue #108
