### PR TITLE
update mariadb example to v1

### DIFF
--- a/examples/mariadb-centos7-atomicapp/artifacts/kubernetes/mariadb-pod.yaml
+++ b/examples/mariadb-centos7-atomicapp/artifacts/kubernetes/mariadb-pod.yaml
@@ -1,25 +1,25 @@
-apiVersion: v1beta1
+apiVersion: v1
 id: mariadb
-desiredState:
-  manifest:
-    version: v1beta1
-    id: mariadb
-    containers:
-      - name: mariadb
-        image: centos/mariadb
-        env:
-          - name: MYSQL_ROOT_PASSWORD
-            value: $root_pass
-          - name: MYSQL_DATABASE
-            value: $db_name
-          - name: MYSQL_USER
-            value: $db_user
-          - name: MYSQL_PASSWORD
-            value: $db_pass
-        cpu: 100
-        ports:
-          - containerPort: 3306
-labels:
+spec:
+  containers:
+    - resources:
+        limits:
+          cpu: 100
+      name: mariadb
+      image: centos/mariadb
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: $root_pass
+        - name: MYSQL_DATABASE
+          value: $db_name
+        - name: MYSQL_USER
+          value: $db_user
+        - name: MYSQL_PASSWORD
+          value: $db_pass
+      ports:
+        - containerPort: 3306
+metadata:
   name: mariadb
+  labels:
+    name: mariadb
 kind: Pod
-

--- a/examples/mariadb-centos7-atomicapp/artifacts/kubernetes/mariadb-service.yaml
+++ b/examples/mariadb-centos7-atomicapp/artifacts/kubernetes/mariadb-service.yaml
@@ -1,10 +1,19 @@
 kind: Service
-apiVersion: v1beta1
-id: mariadb
-port: 3306
-selector:
+apiVersion: v1
+metadata:
   name: mariadb
-containerPort: 3306
-labels:
-  name: mariadb
-
+  labels:
+    name: mariadb
+spec:
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+      nodePort: 0
+  selector:
+    name: mariadb
+  portalIP: None
+  type: ClusterIP
+  sessionAffinity: None
+status:
+  loadBalancer: {}


### PR DESCRIPTION
This example was failing in openshift. As a v1beta1 example it is good to move it to v1 while making sure it is openshift compatible.

Resolves #135 
