### PR TITLE
fix typos in io.projectatomic.nulecule.providers LABEL 

### DIFF
--- a/examples/guestbook-go/Dockerfile
+++ b/examples/guestbook-go/Dockerfile
@@ -2,7 +2,7 @@ FROM projectatomic/atomicapp:0.1.1
 
 MAINTAINER Jason Brooks <jbrooks@redhat.com>
 
-LABEL io.projectatomic.nulecule.providers = "kubernetes"
+LABEL io.projectatomic.nulecule.providers="kubernetes"
 LABEL io.projectatomic.nulecule.specversion 0.0.2
 
 ADD /Nulecule /Dockerfile README.md /application-entity/

--- a/examples/helloapache/Dockerfile
+++ b/examples/helloapache/Dockerfile
@@ -2,7 +2,7 @@ FROM projectatomic/atomicapp:0.1.1
 
 MAINTAINER Aaron Weitekamp <aweiteka@redhat.com>
 
-LABEL io.projectatomic.nulecule.providers = "kubernetes,docker"
+LABEL io.projectatomic.nulecule.providers="kubernetes,docker"
 LABEL io.projectatomic.nulecule.specversion 0.0.2
 
 ADD /Nulecule /Dockerfile README.md /application-entity/

--- a/examples/mariadb-centos7-atomicapp/Dockerfile
+++ b/examples/mariadb-centos7-atomicapp/Dockerfile
@@ -3,7 +3,7 @@ FROM projectatomic/atomicapp:0.1.1
 MAINTAINER Christoph Görn <goern@redhat.com>
 
 LABEL io.projectatomic.nulecule.specversion 0.0.2
-LABEL io.projectatomic.nulecule.providers = "kubernetes,docker,openshift"
+LABEL io.projectatomic.nulecule.providers="kubernetes,docker,openshift"
 
 ADD /Nulecule gpl-3.0.txt /application-entity/
 ADD /artifacts /application-entity/artifacts

--- a/examples/mariadb-fedora-atomicapp/Dockerfile
+++ b/examples/mariadb-fedora-atomicapp/Dockerfile
@@ -2,7 +2,7 @@ FROM projectatomic/atomicapp:0.1.1
 
 MAINTAINER langdon <langdon@fedoraproject.org>
 
-LABEL io.projectatomic.nulecule.providers = "kubernetes,docker"
+LABEL io.projectatomic.nulecule.providers="kubernetes,docker"
 LABEL io.projectatomic.nulecule.specversion 0.0.2
 
 ADD Nulecule /application-entity/

--- a/examples/redis-centos7-atomicapp/Dockerfile
+++ b/examples/redis-centos7-atomicapp/Dockerfile
@@ -2,7 +2,7 @@ FROM projectatomic/atomicapp:0.1.1
 
 MAINTAINER Jason Brooks <jbrooks@redhat.com>
 
-LABEL io.projectatomic.nulecule.providers = "kubernetes"
+LABEL io.projectatomic.nulecule.providers="kubernetes"
 LABEL io.projectatomic.nulecule.specversion 0.0.2
 
 ADD /Nulecule /Dockerfile README.md /application-entity/

--- a/examples/skydns-atomicapp/Dockerfile
+++ b/examples/skydns-atomicapp/Dockerfile
@@ -2,7 +2,7 @@ FROM projectatomic/atomicapp:0.1.0
 
 MAINTAINER langdon <langdon@fedoraproject.org>
 
-LABEL io.projectatomic.nulecule.providers = "kubernetes"
+LABEL io.projectatomic.nulecule.providers="kubernetes"
 LABEL io.projectatomic.nulecule.specversion 0.0.2
 
 LABEL Build docker build --rm --tag testing/skydns-atomicapp .

--- a/examples/wordpress-centos7-atomicapp/Dockerfile
+++ b/examples/wordpress-centos7-atomicapp/Dockerfile
@@ -3,7 +3,7 @@ FROM projectatomic/atomicapp:0.1.1
 MAINTAINER Christoph Görn <goern@redhat.com>
 
 LABEL io.projectatomic.nulecule.specversion 0.0.2
-LABEL io.projectatomic.nulecule.providers "kubernetes, openshift"
+LABEL io.projectatomic.nulecule.providers="kubernetes, openshift"
 
 LABEL Build docker build --rm --tag goern/wordpress-centos7-atomicapp .
 


### PR DESCRIPTION
atomic info shows "=" in the LABELs

ex atomic info IMAGE
io.projectatomic.nulecule.specversion: 0.0.2
io.projectatomic.nulecule.providers: = kubernetes
io.projectatomic.nulecule.atomicappversion: 0.1.1

this is because of 
LABEL io.projectatomic.nulecule.providers = "kubernetes"

which should be
LABEL io.projectatomic.nulecule.providers="kubernetes"
or
LABEL io.projectatomic.nulecule.providers "kubernetes"

more info https://docs.docker.com/userguide/labels-custom-metadata/ 
@goern 
