### PR TITLE
Updates wordpress artificats to v1 compliant

### DIFF
--- a/examples/wordpress-centos7-atomicapp/artifacts/kubernetes/wordpress-pod.yaml
+++ b/examples/wordpress-centos7-atomicapp/artifacts/kubernetes/wordpress-pod.yaml
@@ -1,21 +1,18 @@
-apiVersion: v1beta1
-id: wordpress
-desiredState:
-  manifest:
-    version: v1beta1
-    id: wordpress
-    containers:
-      - name: wordpress
-        image: goern/wordpress 
-        ports:
-          - containerPort: 80
-        env:
-          - name: WORDPRESS_DB_PASSWORD
-            # change this - must match mysql.yaml password
-            value: yourpassword
-          - name: WORDPRESS_DB_USER
-            value: root
-labels:
-  name: frontend
+apiVersion: v1
 kind: Pod
-
+metadata:
+  name: wordpress
+  labels:
+    name: frontend
+spec:
+  containers:
+    - name: wordpress
+      image: goern/wordpress:latest
+      ports:
+        - containerPort: 80
+      env:
+        - name: WORDPRESS_DB_PASSWORD
+          # change this - must match mysql.yaml password
+          value: yourpassword
+        - name: WORDPRESS_DB_USER
+          value: root

--- a/examples/wordpress-centos7-atomicapp/artifacts/kubernetes/wordpress-service.yaml
+++ b/examples/wordpress-centos7-atomicapp/artifacts/kubernetes/wordpress-service.yaml
@@ -1,9 +1,12 @@
+apiVersion: v1
 kind: Service
-apiVersion: v1beta1
-id: frontend
-port: 80
-selector:
+metadata:
   name: frontend
-containerPort: 80
-labels:
-  name: frontend
+  labels:
+    name: frontend
+spec:
+  ports:
+    - port: 80
+      containerPort: 80
+  selector:
+    name: frontend


### PR DESCRIPTION
This patch updates wordpress example's Kubernetes artifacts from v1beta1 to v1.
