### PR TITLE
remove errant id line from redis controller artifacts

### DIFF
--- a/examples/redis-centos7-atomicapp/artifacts/kubernetes/redis-master-controller.json
+++ b/examples/redis-centos7-atomicapp/artifacts/kubernetes/redis-master-controller.json
@@ -1,7 +1,6 @@
 {
    "kind":"ReplicationController",
    "apiVersion":"v1",
-   "id":"redis-master",
    "metadata":{
       "name":"redis-master",
       "labels":{

--- a/examples/redis-centos7-atomicapp/artifacts/kubernetes/redis-slave-controller.json
+++ b/examples/redis-centos7-atomicapp/artifacts/kubernetes/redis-slave-controller.json
@@ -1,7 +1,6 @@
 {
    "kind":"ReplicationController",
    "apiVersion":"v1",
-   "id":"redis-slave",
    "metadata":{
       "name":"redis-slave",
       "labels":{


### PR DESCRIPTION
This id line causes these artifacts to fail to validate w/ kube 1.1, the example runs fine on kube 1 w/o it.
