### PR TITLE
Fixes resource specification in mariadb example.

### DIFF
--- a/examples/mariadb-centos7-atomicapp/artifacts/kubernetes/mariadb-pod.yaml
+++ b/examples/mariadb-centos7-atomicapp/artifacts/kubernetes/mariadb-pod.yaml
@@ -4,7 +4,7 @@ spec:
   containers:
     - resources:
         limits:
-          cpu: 100
+          cpu: 100m
       name: mariadb
       image: centos/mariadb
       env:


### PR DESCRIPTION
kubernetes cpu specification is in milli-cores so 100 would represent
100 cpus while 100m will represent .1 cpus.
