### PR TITLE
Implement param pointers to Nulecule spec.

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -186,6 +186,42 @@ Field Name | Type | Description
 <a name="parametersDefault"></a>default | `string` | **Optional** An optional default value for the parameter.
 <a name="parametersHidden"></a>hidden | `string` | **Optional** An optional boolean signifying the parameter should be obscured when displayed.
 
+##### JSON Pointers 
+JSON Pointers (otherwise known as XPathing) are supported by the Nulecule specification by implementing [RFC 6902](https://tools.ietf.org/html/rfc6902).
+A value can be provided by using the pointer reference within the JSON/Yaml format.
+
+ex.
+```yaml
+description: mongoDB Admin password
+hidden: true
+constraints:
+  - allowed_pattern: "[A-Z0-9]+"
+    description: Must consist of characters and numbers only.
+    default: 0
+    param:
+      - /spec/containers/0/param
+```
+```json
+{
+  "name": "password",
+  "description": "mongoDB Admin password",
+  "hidden": true,
+  "constraints": [
+    {
+      "allowed_pattern": "[A-Z0-9]+",
+      "description": "Must consist of characters and numbers only.",
+      "default": 0,
+      "param": {
+          "description": "An array of JSON pointers per RFC 6902.",
+          "type": "array",
+          "default": null
+      }
+    }
+  ]
+}
+```
+
+
 ##### Parameters Object Example:
 
 ```yaml

--- a/spec/param.json
+++ b/spec/param.json
@@ -29,9 +29,10 @@
             "type": "boolean",
             "default": false
         },
-        "param": [
-          "/spec/containers/0/param",
-          "/spec/containers/1/param"
-        ]
+        "param": {
+            "description": "An array of XPath strings per RFC 6902.",
+            "type": "array",
+            "default": "null"
+        }
     }
 }

--- a/spec/param.json
+++ b/spec/param.json
@@ -28,6 +28,10 @@
             "description": "An optional boolean signifying the parameter should be obscured when displayed.",
             "type": "boolean",
             "default": false
-        }
+        },
+        "param": [
+          "/spec/containers/0/param",
+          "/spec/containers/1/param"
+        ]
     }
 }


### PR DESCRIPTION
This implements XPathing as per the Atomic App PR https://github.com/projectatomic/atomicapp/pull/366.

Fixes issue #70.

I'm not too good at modfying / changing spec information, so will need some input from @bexelbie and @aweiteka
